### PR TITLE
fix(ci): commit linting not callable from remote

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -5,6 +5,7 @@ name: Lint Commit message
 on:
   push:
   pull_request:
+  workflow_call:
 
 jobs: 
   commitlint:


### PR DESCRIPTION
## Description

needs this to be called from other repos
